### PR TITLE
Security, Performance and bugfix release

### DIFF
--- a/Database/Collection.php
+++ b/Database/Collection.php
@@ -87,7 +87,7 @@
 			 * @return mixed
 			 */
 			#[\ReturnTypeWillChange]
-			public function current() {
+			public function current() : mixed {
 				return current($this->items);
 			}
 
@@ -97,7 +97,7 @@
 			 * @return mixed
 			 */
 			#[\ReturnTypeWillChange]
-			public function key() {
+			public function key() : mixed {
 				return key($this->items);
 			}
 

--- a/Database/Connection.php
+++ b/Database/Connection.php
@@ -320,9 +320,6 @@
 			* @since 1.0
 			*/
 			public function fetchRow(string $table, ?array $criteria = null) : ?\stdClass {
-				//$sql = "SELECT * FROM `".$this->safeTable($table)."` WHERE ".$this->keysToSql($criteria, "AND")." LIMIT 1";
-				//$row = $this->query($sql, $criteria)->fetch();
-				//return  $row !== false ? $row : null;
 				return $this->select($table, $criteria)->getFirst();
 			}
 
@@ -336,10 +333,7 @@
 			* @since 1.0
 			*/
 			public function fetchCell(string $table, string $column, ?array $criteria = null) {
-				//$sql = "SELECT * FROM `".$this->safeTable($table)."` WHERE ".$this->keysToSql($criteria, "AND")." LIMIT 1";
-				return $this->select($table, $criteria)->getColumn($column)[0] ?? null;
-				//return $this->query($sql, $criteria)->fetch()?->$column;
-			}
+				return $this->select($table, $criteria)->getColumn($column)[0] ?? null;			}
 
 			/**
 			* Alias of \Database\Connection::fetchCell implemented for the drupal developers sake.

--- a/Database/Connection.php
+++ b/Database/Connection.php
@@ -4,7 +4,6 @@
 	* Easily perform SQL queries without writing (more than neccesary) SQL.
 	* Credits to Mikkel Jensen & Victoria Hansen from whom I in cold blood have undeterred copied some of this code from.
 	*
-	* @author Allan Thue Rehhoff
 	* @version 3.2.1
 	*/
 	namespace Database {

--- a/Database/Connection.php
+++ b/Database/Connection.php
@@ -36,6 +36,12 @@
 			/** @var int Number When an array is passed as criteria this will be incremented for each value across all arrays */
 			protected int $arrayINCounter = 0;
 
+			/** @var string $database The database currently in use */
+			public string $database = '';
+
+			/** @var array $tables Whitelist of tables in initially selected database */
+			public array $tables = [];
+
 			/**
 			* Initiate a new database connection using PDO as a driver.
 			*
@@ -92,10 +98,11 @@
 			* @since 3.0
 			*/
 			public function connect(string $hostname, string $username, string $password, string $database) : Connection {
-				$this->dbh = new \PDO("mysql:host=".$hostname.";dbname=".$database, $username, $password);
+				$this->dbh = new \PDO("mysql:host=".$hostname, $username, $password);
 				$this->dbh->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
 				$this->dbh->setAttribute(\PDO::ATTR_STATEMENT_CLASS, ["Database\Statement", [$this]]);
-				$this->dbh->query("SET NAMES utf8mb4");
+
+				$this->use($database);
 
 				return $this;
 			}
@@ -130,6 +137,21 @@
 			*/
 			public function getConnection() : Connection {
 				return $this;
+			}
+
+			/**
+			 * Switch database to use
+			 * @param string $database
+			 * @return void
+			 */
+			public function use(string $database) : void {
+				$this->query("USE ".$database);
+				$this->query("SET NAMES utf8mb4");
+
+				$this->database = $database;
+
+				$this->tables = $this->query("SHOW TABLES")->fetchCol();
+				$this->tables = array_flip($this->tables);
 			}
 
 			/**
@@ -275,26 +297,14 @@
 			* @todo Find out if this can be replaced by countQuery();
 			* @return int
 			*/
-			public function count(string $table, string $column, ?array $criteria = null) : int {
-				$sql = "SELECT COUNT(`".$column."`) AS total FROM `".$table."`";
+			public function count(string $table, ?array $criteria = null) : int {
+				$sql = "SELECT * FROM `".$this->safeTable($table)."`";
 
 				if($criteria != null) {
 					$sql .= ' WHERE ' . $this->keysToSql($criteria, 'AND');
 				}
 
-				return (int)$this->query($sql, $criteria)->fetch()->total;
-			}
-
-			/**
-			 * Count the results of a query
-			 * 
-			 * @param string $query the parameterized query
-			 * @param array $criteria Key value pairs to use with the query
-			 * @return int Row coutn
-			 */
-			public function countQuery(string $query, array $criteria = []) : int {
-				$result = $this->query($query, $criteria);
-				return (int)$result->rowCount();
+				return (int)$this->query($sql, $criteria)->rowCount();
 			}
 
 			/**
@@ -307,7 +317,7 @@
 			* @since 1.0
 			*/
 			public function fetchRow(string $table, ?array $criteria = null) : ?\stdClass {
-				$sql = "SELECT * FROM `".$table."` WHERE ".$this->keysToSql($criteria, "AND")." LIMIT 1";
+				$sql = "SELECT * FROM `".$this->safeTable($table)."` WHERE ".$this->keysToSql($criteria, "AND")." LIMIT 1";
 				$row = $this->query($sql, $criteria)->fetch();
 				return  $row !== false ? $row : null;
 			}
@@ -322,8 +332,8 @@
 			* @since 1.0
 			*/
 			public function fetchCell(string $table, string $column, ?array $criteria = null) {
-				$sql = "SELECT `".$column."` FROM `".$table."` WHERE ".$this->keysToSql($criteria, "AND")." LIMIT 1";
-				return $this->query($sql, $criteria)->fetchColumn(0);
+				$sql = "SELECT * FROM `".$this->safeTable($table)."` WHERE ".$this->keysToSql($criteria, "AND")." LIMIT 1";
+				return $this->query($sql, $criteria)->fetch()?->$column;
 			}
 
 			/**
@@ -331,8 +341,8 @@
 			*
 			* @see \Database\Connection::fetchCell();
 			*/
-			public function fetchField(string $table, string $column, ?array $criteria = null) {
-				return $this->fetchCell(...func_get_args());
+			public function fetchField(...$args) {
+				return $this->fetchCell(...$args);
 			}
 
 			/**
@@ -344,9 +354,11 @@
 			* @param array $criteria Criteria used to filter the rows.
 			* @return array Returns an array containing all the rows matching in the resultset
 			* @since 2.4
+			* @todo Inspect if this method can be replaced by \Database\Collection::getColumn();
+			*		To future me, keep in mind the provided solution should be able to handle large result sets
 			*/
 			public function fetchCol(string $table, string $column, ?array $criteria = null) : array {
-				$sql = "SELECT `".$column."` FROM `".$table."` WHERE ".$this->keysToSql($criteria, "AND");
+				$sql = "SELECT `".$column."` FROM `".$this->safeTable($table)."` WHERE ".$this->keysToSql($criteria, "AND");
 				return $this->query($sql, $criteria)->fetchCol();
 			}
 
@@ -359,7 +371,7 @@
 			* @since 1.0
 			*/
 			public function select(string $table, ?array $criteria = null) : array {
-				$sql = "SELECT * FROM ".$table." WHERE ".$this->keysToSql($criteria, "AND");
+				$sql = "SELECT * FROM ".$this->safeTable($table)." WHERE ".$this->keysToSql($criteria, "AND");
 				return $this->query($sql, $criteria)->fetchAll();
 			}
 
@@ -373,7 +385,7 @@
 			 * @since 3.1.3
 			 */
 			public function search(string $table, array $searches = [], ?array $criteria = null) : array {
-				$sql = "SELECT * FROM ".$table." WHERE ".implode(" AND ", $searches);
+				$sql = "SELECT * FROM ".$this->safeTable($table)." WHERE ".implode(" AND ", $searches);
 				return $this->query($sql, $criteria)->fetchAll();
 			}
 
@@ -401,7 +413,7 @@
 					$binds[] = implode(', ', $keys);
 				}
 
-				$sql = "INSERT INTO "."`$table` (`" . implode("`, `", array_keys($variables[0])) . "`) VALUES (" . implode("), (", $binds) . ")";
+				$sql = "INSERT INTO "."`".$this->safeTable($table)."` (`" . implode("`, `", array_keys($variables[0])) . "`) VALUES (" . implode("), (", $binds) . ")";
 
 				return $this->query($sql, $values);
 			}
@@ -467,7 +479,7 @@
 				foreach ($variables as $key => $value) $args["new_".$key] = $value;
 				foreach ($criteria as $key => $value) $args["old_".$key] = $value;
 				
-				$sql = "UPDATE `".$table."` SET ".$this->keysToSql($variables, ",", "new_")." WHERE ".$this->keysToSql($criteria, " AND ", "old_");
+				$sql = "UPDATE `".$this->safeTable($table)."` SET ".$this->keysToSql($variables, ",", "new_")." WHERE ".$this->keysToSql($criteria, " AND ", "old_");
 				return $this->query($sql, $args)->rowCount();
 			}
 
@@ -481,7 +493,7 @@
 			* @todo Return affected row count
 			*/
 			public function delete(string $table, ?array $criteria = null) : int {
-				$sql = "DELETE FROM `".$table."` WHERE ".$this->keysToSql($criteria, " AND");
+				$sql = "DELETE FROM `".$this->safeTable($table)."` WHERE ".$this->keysToSql($criteria, " AND");
 				return $this->query($sql, $criteria)->rowCount();
 			}
 
@@ -502,7 +514,7 @@
 					$binds[] = ":".$key;
 				}
 
-				$sql = $type . " INTO "."`$table` (`" . implode("`, `", array_keys($variables)) . "`) VALUES (" . implode(", ", $binds) . ")";
+				$sql = $type . " INTO "."`".$this->safeTable($table)."` (`" . implode("`, `", array_keys($variables)) . "`) VALUES (" . implode(", ", $binds) . ")";
 
 				return $sql;
 			}
@@ -596,6 +608,19 @@
 			*/
 			public function lastInsertId($seqname = null) : int {
 				return $this->dbh->lastInsertId($seqname);
+			}
+
+			/**
+			 * Checks if table name is safe and returns it.
+			 * @return string $table The table name to check
+			 * @throws \InvalidArgumentException
+			 */
+			public function safeTable(string $table) {
+				if(($this->tables[$table] ?? null) === null) {
+					throw new \InvalidArgumentException(sprintf("'%s' is not a valid table in %s",  $table, $this->database));
+				}
+
+				return $table;
 			}
 		}
 	}

--- a/Database/Connection.php
+++ b/Database/Connection.php
@@ -149,7 +149,7 @@
 
 				$this->database = $database;
 
-				$this->tables = $this->query("SHOW TABLES")->fetchCol();
+				$this->tables = $this->query("SHOW TABLES")->fetchAll(\PDO::FETCH_COLUMN, 0);
 				$this->tables = array_flip($this->tables);
 			}
 

--- a/Database/Connection.php
+++ b/Database/Connection.php
@@ -10,16 +10,16 @@
 	namespace Database {
 		class Connection {
 			/** @var boolean True if a transaction has started, false otherwise. */
-			private $transactionStarted = false;
+			protected $transactionStarted = false;
 
 			/** @var object  The singleton instance of the this class. */
-			private static $singletonInstance;
+			protected static $singletonInstance;
 
 			/** @var ?\PDO PDO Database handle */
-			private ?\PDO $dbh;
+			protected ?\PDO $dbh;
 
 			/** @var ?array Filters to prepare before querying */
-			private ?array $filters = [];
+			protected ?array $filters = [];
 
 			/** @var ?Statement Holds the last prepared statement after execution. */
 			public ?Statement $statement;
@@ -34,7 +34,7 @@
 			public ?string $lastQuery = null;
 
 			/** @var int Number When an array is passed as criteria this will be incremented for each value across all arrays */
-			private int $arrayINCounter = 0;
+			protected int $arrayINCounter = 0;
 
 			/**
 			* Initiate a new database connection using PDO as a driver.
@@ -372,7 +372,7 @@
 			 * @return array
 			 * @since 3.1.3
 			 */
-			public function search(string $table, array $searches = [], ?array $criteria = null) {
+			public function search(string $table, array $searches = [], ?array $criteria = null) : array {
 				$sql = "SELECT * FROM ".$table." WHERE ".implode(" AND ", $searches);
 				return $this->query($sql, $criteria)->fetchAll();
 			}

--- a/Database/Entity.php
+++ b/Database/Entity.php
@@ -3,11 +3,9 @@
 * The base class for any CRUD'able entity.
 */
 namespace Database {
-	use Exception;
-
 	/**
-	* Represents a CRUD'able entity.
-	*/
+	 * Represents a CRUD'able entity.
+	 */
 	abstract class Entity {
 		/**
 		 * @var mixed $key Value of the primary key field
@@ -20,11 +18,19 @@ namespace Database {
 		protected array $data = [];
 
 		/**
-		 * Subclasses must define the following two methods
-		 * as 'late static binding' will be used to load
+		 * Subclasses must define getKeyField
+		 * 'late static binding' will be used to load
 		 * entities, and identify primary key + table.
+		 * @return string
 		 */
 		abstract protected static function getKeyField() : string;
+
+		/**
+		 * Subclasses must define getTableName
+		 * 'late static binding' will be used to load
+		 * entities, and identify primary key + table.
+		 * @return string
+		 */
 		abstract protected static function getTableName() : string;
 
 		/**
@@ -49,7 +55,7 @@ namespace Database {
 		*
 		* @return string
 		*/
-		function __toString() {
+		public function __toString() : string {
 			$result = get_class($this)."(".$this->key."):\n";
 			foreach ($this->data as $key => $value) {
 				$result .= " [".$key."] ".$value."\n";
@@ -100,7 +106,7 @@ namespace Database {
 		*/
 		#[\ReturnTypeWillChange]
 		public function save() : mixed {
-			if ($this->exists() === true) {
+			if($this->exists() === true) {
 				Connection::getInstance()->update($this->getTableName(), $this->data, $this->getKeyFilter());
 				return $this->data;
 			} else {
@@ -190,10 +196,7 @@ namespace Database {
 		 * @return Entity
 		 */
 		public static function from(string $field, mixed $value) : Entity {
-			$row = Connection::getInstance()->fetchRow(static::getTableName(), [
-				$field => $value
-			]);
-
+			$row = Connection::getInstance()->fetchRow(static::getTableName(), [$field => $value]);
 			return new static($row);
 		}
 
@@ -285,7 +288,7 @@ namespace Database {
 		* @return mixed the key value
 		*/
 		public function getKey() {
-			return is_numeric($this->key) ? (int)$this->key : $this->safe(static::getKeyField());
+			return is_numeric($this->key) ? (int)$this->key : htmlspecialchars($this->key, ENT_QUOTES, "UTF-8");;
 		}
 
 		/**
@@ -302,7 +305,7 @@ namespace Database {
 		*
 		* @return mixed A key value
 		*/
-		public function id() {
+		public function id() : mixed {
 			return $this->getKey();
 		}
 

--- a/Database/Entity.php
+++ b/Database/Entity.php
@@ -174,9 +174,15 @@ namespace Database {
 				$field => $value
 			]);
 
-			$class = get_called_class();
+			return new static($ID);
+		}
 
-			return new $class($ID);
+		/**
+		 * Creates a new instance of any given entity
+		 * @return Entity
+		 */
+		public static function new() : Entity {
+			return new static;
 		}
 
 		/**

--- a/Database/Statement.php
+++ b/Database/Statement.php
@@ -1,9 +1,6 @@
 <?php
 	namespace Database {
-		use PDO;
-		use PDOStatement;
-
-		class Statement extends PDOStatement {
+		class Statement extends \PDOStatement {
 			/**
 			 * Dear future me, PDOStatement has no __construct() method
 			 * No need not to add a parent::__construct(); call in here
@@ -16,7 +13,7 @@
 			 * @return array
 			 */
 			public function fetchCol() : array {
-				$result = $this->fetchAll(PDO::FETCH_COLUMN);
+				$result = $this->fetchAll(\PDO::FETCH_COLUMN);
 				
 				// PHP < 8.0.0 compat. PDOStatement::fetchAll(); will return false
 				// if the result set was empty, fixed in PHP 8.0.0
@@ -29,7 +26,7 @@
 			 * This method will make sure NULL may be return instead
 			 * @return mixed
 			 */
-			public function fetch(int $mode = PDO::FETCH_DEFAULT, int $cursorOrientation = PDO::FETCH_ORI_NEXT, int $cursorOffset = 0) : mixed {
+			public function fetch(int $mode = \PDO::FETCH_DEFAULT, int $cursorOrientation = \PDO::FETCH_ORI_NEXT, int $cursorOffset = 0) : mixed {
 				$result = parent::fetch($mode, $cursorOrientation, $cursorOffset);
 				
 				// PDOStatement::fetchColumn(); will return false

--- a/Database/Statement.php
+++ b/Database/Statement.php
@@ -23,11 +23,28 @@
 				return $result !== false ? $result : [];
 			}
 
-			public function fetchColumn(int $column = 0): mixed {
-				$result = parent::fetchColumn($column);
-
+			/**
+			 * Fetches the next row from a result set 
+			 * \PDOStatement::fetchColumn(); will return false
+			 * This method will make sure NULL may be return instead
+			 * @return mixed
+			 */
+			public function fetch(int $mode = PDO::FETCH_DEFAULT, int $cursorOrientation = PDO::FETCH_ORI_NEXT, int $cursorOffset = 0) : mixed {
+				$result = parent::fetch($mode, $cursorOrientation, $cursorOffset);
+				
 				// PDOStatement::fetchColumn(); will return false
 				// We'll normalise it to return null
+				return $result !== false ? $result : null;
+			}
+
+			/**
+			 * Fetch a column by numeric index from the resultset
+			 * \PDOStatement::fetchColumn(); will return false
+			 * This method will make sure NULL may be return instead
+			 * @return mixed
+			 */
+			public function fetchColumn(int $column = 0): mixed {
+				$result = parent::fetchColumn($column);
 				return $result !== false ? $result : null;
 			}
 		}

--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -1,0 +1,64 @@
+<?php
+	/**
+	* Tests Entity class against various common use cases
+	*/
+	class CollectionTest extends PHPUnit\Framework\TestCase {
+		private static $db;
+
+		/**
+		 * Sets up the required database connection
+		 */
+		public static function setUpBeforeClass() :void {
+			self::$db = db();
+		}
+
+		/**
+		 * Cleans up the table after testing, since i dont want the table we are testing against to clutter up with random crap.
+		 */
+		public static function tearDownAfterClass() :void {
+			self::$db->delete("movies");
+			self::$db->delete("test_table");
+			self::$db->query("ALTER TABLE movies AUTO_INCREMENT = 0");
+		}
+
+		public function testGetColumnIsNotEmpty() {
+			$insertId = self::$db->insert("movies", ["movie_name" => "Star wars new war", "added" => date("Y-m-d h:i:s")]);
+
+			$res = self::$db->select("movies", ["mid" => [$insertId]])->getColumn("movie_name");
+
+			$this->assertNotEmpty($res);
+		}
+
+		/**
+		 * Test Collection::getColumn
+		 */
+		public function testGetColumnReturnsCollection() {
+			$insertId = self::$db->insert("movies", ["movie_name" => "Star wars new war", "added" => date("Y-m-d h:i:s")]);
+
+			$res = self::$db->select("movies", ["mid" => [$insertId]])->getColumn("movie_name");
+
+			$this->assertInstanceOf(\Database\Collection::class, $res);
+		}
+
+		/**
+		 * Test Collection::getFirst
+		 */
+		public function testGetFirst() {
+			$insertId = self::$db->insert("movies", ["movie_name" => "Star wars new war", "added" => date("Y-m-d h:i:s")]);
+
+			$res = self::$db->select("movies", ["mid" => [$insertId]]);
+
+			$this->assertEquals($res->getFirst()->movie_name, "Star wars new war");
+		}
+
+		/**
+		 * Test Collection::getColumn and Collection::getFirst
+		 */
+		public function testGetColumnAndFirst() {
+			$insertId = self::$db->insert("movies", ["movie_name" => "Star wars new war", "added" => date("Y-m-d h:i:s")]);
+
+			$res = self::$db->select("movies", ["mid" => [$insertId]]);
+
+			$this->assertEquals($res->getColumn("movie_name")->getFirst(), $res->getFirst()->movie_name);
+		}
+	}

--- a/tests/DatabaseConnectionTest.php
+++ b/tests/DatabaseConnectionTest.php
@@ -9,16 +9,16 @@
 		* Sets up the required database connection
 		*/
 		public static function setUpBeforeClass() :void {
-			self::$db = new \Database\Connection(DB_HOST, DB_USER, DB_PASS, DB_NAME);
+			self::$db = db();
 		}
 
 		/**
 		* Cleans up the table after testing, since i dont want the table we are testing against to clutter up with random crap.
 		*/
 		public static function tearDownAfterClass() :void {
-			self::$db->query("ALTER TABLE movies AUTO_INCREMENT = 0");
 			self::$db->delete("movies");
 			self::$db->delete("test_table");
+			self::$db->query("ALTER TABLE movies AUTO_INCREMENT = 0");
 		}
 
 		public function testSingletonIsInstanceOfDatabaseConnection() {
@@ -303,18 +303,6 @@
 		public function testFetchCellReturnsNullOnEmpty() {
 			$res = self::$db->fetchCell("movies", "movie_name", ["mid" => "-1"]);
 			$this->assertNull($res);
-		}
-
-		public function testFetchColumn() {
-			$insertId = self::$db->insert("movies", ["movie_name" => "Star wars new war", "added" => date("Y-m-d h:i:s")]);
-
-			$res1 = self::$db->query("SELECT movie_name FROM movies WHERE mid in :mid", ["mid" => [$insertId]])->fetchCol();
-			$this->assertNotEmpty($res1);
-
-			$res2 = self::$db->fetchCol("movies", "movie_name", ["mid" => $insertId]);
-			$this->assertNotEmpty($res2);
-
-			$this->assertEquals($res1, $res2);
 		}
 
 		public function testSimpleQueryDebugging() {

--- a/tests/DatabaseConnectionTest.php
+++ b/tests/DatabaseConnectionTest.php
@@ -304,7 +304,6 @@
 
 		public function testFetchCellReturnsNullOnEmpty() {
 			$res = $this->db->fetchCell("movies", "movie_name", ["mid" => "-1"]);
-			$res = $this->db->fetchField("movies", "movie_name", ["mid" => "-1"]);
 			$this->assertNull($res);
 		}
 

--- a/tests/DatabaseConnectionTest.php
+++ b/tests/DatabaseConnectionTest.php
@@ -171,7 +171,7 @@
 				]);
 			}
 
-			$res = self::$db->count("test_table", "test_id", ["varchar_col" => null]);
+			$res = self::$db->count("test_table", ["varchar_col" => null]);
 
 			$this->assertEquals($res, 2);
 		}
@@ -187,7 +187,7 @@
 				]);
 			}
 
-			$res = self::$db->count("test_table", "test_id", ["varchar_col" => 2]);
+			$res = self::$db->count("test_table", ["varchar_col" => 2]);
 
 			$this->assertEquals($res, 3);
 		}
@@ -203,8 +203,8 @@
 				]);
 			}
 
-			$true = self::$db->count("test_table", "test_id", ["varchar_col" => true]);
-			$false = self::$db->count("test_table", "test_id", ["varchar_col" => false]);
+			$true = self::$db->count("test_table", ["varchar_col" => true]);
+			$false = self::$db->count("test_table", ["varchar_col" => false]);
 
 			$this->assertEquals($true, 1);
 			$this->assertEquals($false, 1);

--- a/tests/DatabaseConnectionTest.php
+++ b/tests/DatabaseConnectionTest.php
@@ -3,26 +3,22 @@
 	* Quickly test most frequent use cases for the DatabaseConnection() class
 	*/
 	class DatabaseConnectionTest extends PHPUnit\Framework\TestCase {
-		private $db;
+		private static $db;
 
 		/**
 		* Sets up the required database connection
 		*/
-		public function setUp() :void {
-			try {
-				$this->db = new \Database\Connection(DB_HOST, DB_USER, DB_PASS, DB_NAME);
-			} catch(Exception $e) {
-				$this->fail($e->getMessage());
-			}
+		public static function setUpBeforeClass() :void {
+			self::$db = new \Database\Connection(DB_HOST, DB_USER, DB_PASS, DB_NAME);
 		}
 
 		/**
 		* Cleans up the table after testing, since i dont want the table we are testing against to clutter up with random crap.
 		*/
-		public function tearDown() :void {
-			$this->db->query("ALTER TABLE movies AUTO_INCREMENT = 0");
-			$this->db->delete("movies");
-			$this->db->delete("test_table");
+		public static function tearDownAfterClass() :void {
+			self::$db->query("ALTER TABLE movies AUTO_INCREMENT = 0");
+			self::$db->delete("movies");
+			self::$db->delete("test_table");
 		}
 
 		public function testSingletonIsInstanceOfDatabaseConnection() {
@@ -33,13 +29,13 @@
 			$sql = "SELECT * FROM movies WHERE movie_name = :movie_name";
 			$args = ["movie_name" => "test"];
 
-			$statement = $this->db->prepare($sql, $args);
+			$statement = self::$db->prepare($sql, $args);
 
 			$this->assertInstanceOf("Database\Statement", $statement);
 		}
 
 		public function testInsertSingleRow() {
-			$insertId = $this->db->insert("movies", ["movie_name" => "test", "added" => date("Y-m-d h:i:s")]);
+			$insertId = self::$db->insert("movies", ["movie_name" => "test", "added" => date("Y-m-d h:i:s")]);
 			$this->assertIsInt($insertId);
 		}
 
@@ -61,82 +57,82 @@
 				]
 			];
 
-			$numInserted = $this->db->insertMultiple("movies", $data)->rowCount();
+			$numInserted = self::$db->insertMultiple("movies", $data)->rowCount();
 
 			$this->assertEquals(count($data), $numInserted);
 		}
 
 		public function testReplaceRowWithExistingPrimaryKey() {
-			$insertId = $this->db->insert("movies", ["movie_name" => "test", "added" => date("Y-m-d h:i:s")]);
+			$insertId = self::$db->insert("movies", ["movie_name" => "test", "added" => date("Y-m-d h:i:s")]);
 
-			$this->db->replace("movies", ["mid" => $insertId, "movie_name" => "test2", "added" => date("Y-m-d h:i:s")]);
-			$movieName = $this->db->fetchCell("movies", "movie_name", ["mid" => $insertId]);
+			self::$db->replace("movies", ["mid" => $insertId, "movie_name" => "test2", "added" => date("Y-m-d h:i:s")]);
+			$movieName = self::$db->fetchCell("movies", "movie_name", ["mid" => $insertId]);
 			$this->assertEquals("test2", $movieName);
 		}
 
 		public function testInsertAndDeleteRow() {
-			$insertId = $this->db->insert("movies", ["movie_name" => "test", "added" => date("Y-m-d h:i:s")]);
-			$rowsAffected = $this->db->delete("movies", ["mid" => $insertId]);
+			$insertId = self::$db->insert("movies", ["movie_name" => "test", "added" => date("Y-m-d h:i:s")]);
+			$rowsAffected = self::$db->delete("movies", ["mid" => $insertId]);
 			$this->assertGreaterThan(0, $rowsAffected);
 		}
 		
 		public function testUpdateStatement() {
-			$insertId = $this->db->insert("movies", ["movie_name" => "test name to be updated", "added" => date("Y-m-d h:i:s")]);
+			$insertId = self::$db->insert("movies", ["movie_name" => "test name to be updated", "added" => date("Y-m-d h:i:s")]);
 
-			$this->db->update("movies", ["movie_name" => time()], ["mid" => $insertId]);
+			self::$db->update("movies", ["movie_name" => time()], ["mid" => $insertId]);
 
-			$rowcount = $this->db->update("movies", ["movie_name" => "Star wars"], ["mid" => $insertId]);
+			$rowcount = self::$db->update("movies", ["movie_name" => "Star wars"], ["mid" => $insertId]);
 			$this->assertEquals(1, $rowcount);
 		}
 
 		public function testInsertAndUpdateSingleRow() {
 			$newMovieName = "Exciting new movie";
 
-			$insertId = $this->db->insert("movies", ["movie_name" => "Old boring movie.", "added" => date("Y-m-d h:i:s")]);
+			$insertId = self::$db->insert("movies", ["movie_name" => "Old boring movie.", "added" => date("Y-m-d h:i:s")]);
 
 			$this->assertIsInt($insertId);
 
-			$rowsAffected = $this->db->update("movies", ["movie_name" => $newMovieName], ["mid" => $insertId]);
+			$rowsAffected = self::$db->update("movies", ["movie_name" => $newMovieName], ["mid" => $insertId]);
 			$this->assertGreaterThan(0, $rowsAffected);
 
-			$updatedRowMovieName = $this->db->fetchCell("movies", "movie_name", ["mid" => $insertId]);
+			$updatedRowMovieName = self::$db->fetchCell("movies", "movie_name", ["mid" => $insertId]);
 			$this->assertEquals($newMovieName, $updatedRowMovieName);
 		}
 
 		public function testRollbackInsert() {
 			// Rollbacks doesn't work with MyISAM engines..
-			$this->db->query("ALTER TABLE movies ENGINE = InnoDB");
+			self::$db->query("ALTER TABLE movies ENGINE = InnoDB");
 
-			$this->db->insert("movies", ["movie_name" => "test", "added" => date("Y-m-d h:i:s")]);
+			self::$db->insert("movies", ["movie_name" => "test", "added" => date("Y-m-d h:i:s")]);
 
-			$latestMovieIdBeforeTransaction = $this->db->query("SELECT mid FROM movies ORDER BY mid DESC LIMIT 1")->fetch()->mid;
-			$start = $this->db->transaction();
+			$latestMovieIdBeforeTransaction = self::$db->query("SELECT mid FROM movies ORDER BY mid DESC LIMIT 1")->fetch()->mid;
+			$start = self::$db->transaction();
 			$this->assertTrue($start);
 
-			$this->db->insert("movies", ["movie_name" => "New movie 2", "added" => date("Y-m-d h:i:s")]);
+			self::$db->insert("movies", ["movie_name" => "New movie 2", "added" => date("Y-m-d h:i:s")]);
 
-			$rollback = $this->db->rollback();
+			$rollback = self::$db->rollback();
 			$this->assertTrue($rollback);
 
-			$latestMovieIdAfterTransaction = $this->db->query("SELECT mid FROM movies ORDER BY mid DESC LIMIT 1")->fetch()->mid;
+			$latestMovieIdAfterTransaction = self::$db->query("SELECT mid FROM movies ORDER BY mid DESC LIMIT 1")->fetch()->mid;
 			$this->assertEquals($latestMovieIdBeforeTransaction, $latestMovieIdAfterTransaction);
 		}
 
 		public function testCommitInsert() {
 			$newMovieName = "boring thing";
 
-			$this->db->insert("movies", ["movie_name" => "test", "added" => date("Y-m-d h:i:s")]);
+			self::$db->insert("movies", ["movie_name" => "test", "added" => date("Y-m-d h:i:s")]);
 
-			$start = $this->db->transaction();
+			$start = self::$db->transaction();
 			$this->assertTrue($start);
 
-			$latestMovieNameBeforeCommit = $this->db->query("SELECT movie_name FROM movies ORDER BY mid DESC LIMIT 1")->fetch()->movie_name;
-			$insertId = $this->db->insert("movies", ["movie_name" => $newMovieName, "added" => date("Y-m-d h:i:s")]);
+			$latestMovieNameBeforeCommit = self::$db->query("SELECT movie_name FROM movies ORDER BY mid DESC LIMIT 1")->fetch()->movie_name;
+			$insertId = self::$db->insert("movies", ["movie_name" => $newMovieName, "added" => date("Y-m-d h:i:s")]);
 
-			$commit = $this->db->commit();
+			$commit = self::$db->commit();
 			$this->assertTrue($commit);
 
-			$latestMovieNameAfterCommit = $this->db->query("SELECT movie_name FROM movies ORDER BY mid DESC LIMIT 1")->fetch()->movie_name;
+			$latestMovieNameAfterCommit = self::$db->query("SELECT movie_name FROM movies ORDER BY mid DESC LIMIT 1")->fetch()->movie_name;
 
 			$this->assertNotEquals($latestMovieNameBeforeCommit, $latestMovieNameAfterCommit);
 		}
@@ -144,71 +140,71 @@
 		public function testOnDuplicateKeyUpdate() {
 			$initVal = bin2hex(random_bytes(16));
 
-			$this->db->upsert("test_table", [
+			self::$db->upsert("test_table", [
 				"test_id" => 110,
 				"varchar_col" => $initVal,
 				"text_col" => "lorem ipsum",
 				"datetime_col" => date("Y-m-d h:i:s")
 			]);
 
-			$this->db->upsert("test_table", [
+			self::$db->upsert("test_table", [
 				"test_id" => 110,
 				"varchar_col" => "newVal",
 				"text_col" => "lorem ipsum",
 				"datetime_col" => date("Y-m-d h:i:s")
 			]);
 			
-			$newVal = $this->db->fetchField("test_table", "varchar_col", ["test_id" => 110]);
+			$newVal = self::$db->fetchField("test_table", "varchar_col", ["test_id" => 110]);
 
 			$this->assertNotEquals($newVal, $initVal);
 			$this->assertEquals($newVal, "newVal");
 		}
 
 		public function testSelectNullValue() {
-			$this->db->delete("test_table", ["varchar_col" => null]);
+			self::$db->delete("test_table", ["varchar_col" => null]);
 
 			foreach(["test1", "test2", "test3", null, null] as $val) {
-				$this->db->insert("test_table", [
+				self::$db->insert("test_table", [
 					"varchar_col" => $val,
 					"text_col" => "lorem ipsum",
 					"datetime_col" => date("Y-m-d h:i:s")
 				]);
 			}
 
-			$res = $this->db->count("test_table", "test_id", ["varchar_col" => null]);
+			$res = self::$db->count("test_table", "test_id", ["varchar_col" => null]);
 
 			$this->assertEquals($res, 2);
 		}
 
 		public function testSelectIntegers() {
-			$this->db->delete("test_table", ["varchar_col" => 2]);
+			self::$db->delete("test_table", ["varchar_col" => 2]);
 
 			foreach([2, 2, 2, null, null, "string", "anotherstring"] as $val) {
-				$this->db->insert("test_table", [
+				self::$db->insert("test_table", [
 					"varchar_col" => $val,
 					"text_col" => "lorem ipsum",
 					"datetime_col" => date("Y-m-d h:i:s"),
 				]);
 			}
 
-			$res = $this->db->count("test_table", "test_id", ["varchar_col" => 2]);
+			$res = self::$db->count("test_table", "test_id", ["varchar_col" => 2]);
 
 			$this->assertEquals($res, 3);
 		}
 
 		public function testSelectBooleans() {
-			$this->db->delete("test_table", ["varchar_col" => [true, false]]);
+			self::$db->delete("test_table", ["varchar_col" => [true, false]]);
 
 			foreach([true, false] as $val) {
-				$this->db->insert("test_table", [
+				self::$db->insert("test_table", [
 					"varchar_col" => $val,
 					"text_col" => "lorem ipsum",
 					"datetime_col" => date("Y-m-d h:i:s"),
 				]);
 			}
 
-			$true = $this->db->count("test_table", "test_id", ["varchar_col" => true]);
-			$false = $this->db->count("test_table", "test_id", ["varchar_col" => false]);
+			$true = self::$db->count("test_table", "test_id", ["varchar_col" => true]);
+			$false = self::$db->count("test_table", "test_id", ["varchar_col" => false]);
 
 			$this->assertEquals($true, 1);
 			$this->assertEquals($false, 1);
@@ -218,11 +214,13 @@
 			$sdb = Database\Connection::getInstance();
 			$this->assertInstanceOf("Database\Connection", $sdb);
 			$res = $sdb->query("SELECT mid FROM movies LIMIT 1")->fetchAll();
+
+			$this->assertEquals(1, count($res));
 		}
 
 		public function testSelectQueryWithoutParameter() {
-			$this->db->insert("movies", ["movie_name" => "test", "added" => date("Y-m-d h:i:s")]);
-			$res = $this->db->query("SELECT mid FROM movies")->fetchAll();
+			self::$db->insert("movies", ["movie_name" => "test", "added" => date("Y-m-d h:i:s")]);
+			$res = self::$db->query("SELECT mid FROM movies")->fetchAll();
 			$this->assertNotEmpty($res);
 		}
 
@@ -238,25 +236,25 @@
 				]
 			];
 
-			$numInserted = $this->db->insertMultiple("movies", $data)->rowCount();
-			$res = $this->db->query("SELECT mid FROM movies WHERE mid > :num", ["num" => 1])->fetchAll();
+			$numInserted = self::$db->insertMultiple("movies", $data)->rowCount();
+			$res = self::$db->query("SELECT mid FROM movies WHERE mid > :num", ["num" => 1])->fetchAll();
 			$this->assertNotEmpty($res);
 		}
 
 		public function testSelectQueryFromWrapperMethod() {
-			$this->db->insert("movies", ["movie_name" => "test", "added" => date("Y-m-d h:i:s")]);
-			$res = $this->db->select("movies");
+			self::$db->insert("movies", ["movie_name" => "test", "added" => date("Y-m-d h:i:s")]);
+			$res = self::$db->select("movies");
 			$this->assertNotEmpty($res);	
 		}
 
 		public function testSelectQueryMethodWithParameters() {
-			$this->db->insert("movies", ["movie_name" => "test", "added" => date("Y-m-d h:i:s")]);
-			$res = $this->db->select("movies", ["movie_name" => "test"]);
+			self::$db->insert("movies", ["movie_name" => "test", "added" => date("Y-m-d h:i:s")]);
+			$res = self::$db->select("movies", ["movie_name" => "test"]);
 			$this->assertNotEmpty($res);
 		}
 
 		public function testSelectQueryMethodWithNegatedParameters() {
-			$this->db->delete("movies");
+			self::$db->delete("movies");
 
 			$date = date("Y-m-d h:i:s");
 
@@ -275,9 +273,9 @@
 				]
 			];
 
-			$numInserted = $this->db->insertMultiple("movies", $data)->rowCount();
+			$numInserted = self::$db->insertMultiple("movies", $data)->rowCount();
 
-			$res = $this->db->search("movies", [
+			$res = self::$db->search("movies", [
 				"movie_name NOT IN :movies"
 			], [
 				"movies" => ["Avatar", "Avatar 2"]
@@ -286,34 +284,34 @@
 		}
 
 		public function testSelectSingleRowFromParameters() {
-			$this->db->insert("movies", ["movie_name" => "Star wars", "added" => date("Y-m-d h:i:s")]);
+			self::$db->insert("movies", ["movie_name" => "Star wars", "added" => date("Y-m-d h:i:s")]);
 
-			$res = $this->db->fetchRow("movies", ["movie_name" => "Star wars"]);
+			$res = self::$db->fetchRow("movies", ["movie_name" => "Star wars"]);
 			$this->assertIsObject($res);
 
-			$res = $this->db->fetchRow("movies", ["mid" => time()]);
+			$res = self::$db->fetchRow("movies", ["mid" => time()]);
 			$this->assertNull($res);
 		}
 
 		public function testFetchSingleCellValueFromParameters() {
 			$movieName = "Star wars fallen order";
-			$insertId = $this->db->insert("movies", ["movie_name" => $movieName, "added" => date("Y-m-d h:i:s")]);
-			$res = $this->db->fetchCell("movies", "movie_name", ["mid" => $insertId]);
+			$insertId = self::$db->insert("movies", ["movie_name" => $movieName, "added" => date("Y-m-d h:i:s")]);
+			$res = self::$db->fetchCell("movies", "movie_name", ["mid" => $insertId]);
 			$this->assertEquals($movieName, $res);
 		}
 
 		public function testFetchCellReturnsNullOnEmpty() {
-			$res = $this->db->fetchCell("movies", "movie_name", ["mid" => "-1"]);
+			$res = self::$db->fetchCell("movies", "movie_name", ["mid" => "-1"]);
 			$this->assertNull($res);
 		}
 
 		public function testFetchColumn() {
-			$insertId = $this->db->insert("movies", ["movie_name" => "Star wars new war", "added" => date("Y-m-d h:i:s")]);
+			$insertId = self::$db->insert("movies", ["movie_name" => "Star wars new war", "added" => date("Y-m-d h:i:s")]);
 
-			$res1 = $this->db->query("SELECT movie_name FROM movies WHERE mid in :mid", ["mid" => [$insertId]])->fetchCol();
+			$res1 = self::$db->query("SELECT movie_name FROM movies WHERE mid in :mid", ["mid" => [$insertId]])->fetchCol();
 			$this->assertNotEmpty($res1);
 
-			$res2 = $this->db->fetchCol("movies", "movie_name", ["mid" => $insertId]);
+			$res2 = self::$db->fetchCol("movies", "movie_name", ["mid" => $insertId]);
 			$this->assertNotEmpty($res2);
 
 			$this->assertEquals($res1, $res2);
@@ -321,14 +319,14 @@
 
 		public function testSimpleQueryDebugging() {
 			$queryInterpolatedCorrect = "SELECT foo FROM bar WHERE baz = 'something'";
-			$queryInterpolatedFromMethod = $this->db->debugQuery("SELECT foo FROM bar WHERE baz = :smth", ["smth" => "something"]);
+			$queryInterpolatedFromMethod = self::$db->debugQuery("SELECT foo FROM bar WHERE baz = :smth", ["smth" => "something"]);
 
 			$this->assertEquals($queryInterpolatedCorrect, $queryInterpolatedFromMethod);
 		}
 
 		public function testDebugQueryUsingInKeyword() {
 			$correctQuery = "SELECT foo FROM bar WHERE baz IN ('this', 'or', 'that')";
-			$queryInterpolated = $this->db->debugQuery("SELECT foo FROM bar WHERE baz IN :arr", ["arr" => ["this", "or", "that"]]);
+			$queryInterpolated = self::$db->debugQuery("SELECT foo FROM bar WHERE baz IN :arr", ["arr" => ["this", "or", "that"]]);
 			$this->assertEquals($correctQuery, $queryInterpolated);
 		}
 	}

--- a/tests/EntityTypeTest.php
+++ b/tests/EntityTypeTest.php
@@ -20,7 +20,7 @@
 		*/
 		public function testInstanceIsEntity() {
 			$entity = new Database\EntityType();
-			$this->assertInstanceOf("Database\EntityType", $entity);
+			$this->assertInstanceOf(Database\EntityType::class, $entity);
 		}
 
 		/**
@@ -37,9 +37,13 @@
 
 			$loadedEntity = Database\EntityType::from("varchar_col", "Yoda the great");
 
-			$this->assertInstanceOf("Database\EntityType", $loadedEntity);
+			$this->assertInstanceOf(Database\EntityType::class, $loadedEntity);
 			$this->assertTrue($loadedEntity->exists());
 			$this->assertEquals("Fear is the path to the dark side.", $loadedEntity->get("text_col"));
+		}
+
+		public function testNewInstance() {
+			$this->assertInstanceOf(Database\EntityType::class, Database\EntityType::new());
 		}
 
 		/**
@@ -73,7 +77,7 @@
 			$testId = $this->db->fetchField("test_table", "test_id", ["varchar_col" => "somevalue"]);
 
 			$entity = Database\EntityType::load($testId);
-			$this->assertInstanceOf("Database\EntityType", $entity);
+			$this->assertInstanceOf(Database\EntityType::class, $entity);
 		}
 
 		/**

--- a/tests/EntityTypeTest.php
+++ b/tests/EntityTypeTest.php
@@ -19,8 +19,11 @@
 		* Test instance works as expected
 		*/
 		public function testInstanceIsEntity() {
-			$entity = new Database\EntityType();
-			$this->assertInstanceOf(Database\EntityType::class, $entity);
+			$this->assertInstanceOf(Database\EntityType::class, new Database\EntityType());
+		}
+
+		public function testNewInstance() {
+			$this->assertInstanceOf(Database\EntityType::class, Database\EntityType::new());
 		}
 
 		/**
@@ -40,10 +43,6 @@
 			$this->assertInstanceOf(Database\EntityType::class, $loadedEntity);
 			$this->assertTrue($loadedEntity->exists());
 			$this->assertEquals("Fear is the path to the dark side.", $loadedEntity->get("text_col"));
-		}
-
-		public function testNewInstance() {
-			$this->assertInstanceOf(Database\EntityType::class, Database\EntityType::new());
 		}
 
 		/**
@@ -73,7 +72,7 @@
 				"text_col" => "Lorem ipsum dolor sit amet"
 			]);
 			$entity->save();
-			
+
 			$testId = $this->db->fetchField("test_table", "test_id", ["varchar_col" => "somevalue"]);
 
 			$entity = Database\EntityType::load($testId);

--- a/tests/EntityTypeTest.php
+++ b/tests/EntityTypeTest.php
@@ -3,16 +3,22 @@
 	* Tests Entity class against various common use cases
 	*/
 	class EntityTypeTest extends PHPUnit\Framework\TestCase {
-		public function setUp() :void {
-			try {
-				$this->db = new Database\Connection(DB_HOST, DB_USER, DB_PASS, DB_NAME);
-			} catch(Exception $e) {
-				$this->fail("Unable to setup tests, perhaps you forgot to configure database credentials.");
-			}
+		private static $db;
+
+		/**
+		* Sets up the required database connection
+		*/
+		public static function setUpBeforeClass() :void {
+			self::$db = db();
 		}
 
-		public function tearDown() :void {
-			$this->db->query("TRUNCATE test_table");
+		/**
+		* Cleans up the table after testing, since i dont want the table we are testing against to clutter up with random crap.
+		*/
+		public static function tearDownAfterClass() :void {
+			self::$db->delete("movies");
+			self::$db->delete("test_table");
+			self::$db->query("ALTER TABLE movies AUTO_INCREMENT = 0");
 		}
 
 		/**
@@ -57,7 +63,7 @@
 			] );
 			$entity->save();
 
-			$this->assertGreaterThan(0, $this->db->lastInsertId());
+			$this->assertGreaterThan(0, self::$db->lastInsertId());
 		}
 
 		/**
@@ -73,7 +79,7 @@
 			]);
 			$entity->save();
 
-			$testId = $this->db->fetchField("test_table", "test_id", ["varchar_col" => "somevalue"]);
+			$testId = self::$db->fetchField("test_table", "test_id", ["varchar_col" => "somevalue"]);
 
 			$entity = Database\EntityType::load($testId);
 			$this->assertInstanceOf(Database\EntityType::class, $entity);
@@ -98,7 +104,7 @@
 			]);
 			$insert_id = $entity->save();
 
-			$this->assertEquals($insert_id, $this->db->lastInsertId());
+			$this->assertEquals($insert_id, self::$db->lastInsertId());
 			$loadedEntity = new Database\EntityType($insert_id);
 
 			$this->assertNotEmpty($loadedEntity);


### PR DESCRIPTION
Some highlights of updates until this release.

- Removed fetch* functions vulnerable to SQL injections, replaced with collections.  
- Allow only whitelisted table names to be used.  
- Optimized tests, from ~500ms down to ~150ms.  
- Optimized base class performance.  
- Updating documentation and typehints according to static analysis.  
- Added \Connection::search method, for those semi-complex query cases.  